### PR TITLE
Bump bouncycastleVersion to 1.84

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ testngVersion=7.6.1
 gsonVersion=2.8.8
 jacocoVersion=0.8.10
 
-bouncycastleVersion=1.80
+bouncycastleVersion=1.84
 pahoMqtt5Version=1.2.5
 
 #stdlib dependencies


### PR DESCRIPTION
## Summary

Bumps `bouncycastleVersion` from `1.80` to `1.84` to address three vulnerabilities detected by Trivy in the `bcpkix-jdk18on` and `bcprov-jdk18on` jars bundled in the distribution.

| CVE | Severity | Artifact | Description |
|-----|----------|----------|-------------|
| CVE-2026-5588 | MEDIUM | bcpkix-jdk18on | PKIX draft CompositeVerifier accepts empty signature sequence as valid |
| CVE-2026-5598 | HIGH | bcprov-jdk18on | Private key leakage via non-constant time comparisons |
| CVE-2026-0636 | MEDIUM | bcprov-jdk18on | LDAP injection vulnerability in LDAPStoreHelper.java |

Fixed in BouncyCastle `1.84`.

## Test plan
- [ ] CI passes
- [ ] Trivy scan no longer reports `bcpkix-jdk18on-1.80.jar` / `bcprov-jdk18on-1.80.jar` vulnerabilities

🤖 Generated with [Claude Code](https://claude.ai/claude-code)