### PR TITLE
Update header formatting in README.md

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,7 +2,7 @@
 
 This module provides an implementation to interact with MQTT servers via an MQTT client and listener, using the lightweight, publish-subscribe MQTT protocol for machine-to-machine messaging.
 
-## Key Features
+### Key Features
 
 - MQTT publisher client for sending messages to a topic
 - MQTT subscriber listener with `onMessage`/`onError` remote methods


### PR DESCRIPTION
## Purpose

Fixes the README so the WSO2 Integration Store correctly displays the Key Features section for this connector. `## Key Features` is demoted to `### Key Features`, nesting it under `## Overview` to match the Store's existing parsing convention.

## Examples

N/A — documentation-only change, no code or behavior affected.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `ballerina/README.md` to change the `Key Features` heading from `##` to `###`.
- Nested the section under `Overview` to improve WSO2 Integration Store parsing and display.
- No code or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->